### PR TITLE
Feature/2 semistandard merge

### DIFF
--- a/.build_scripts/lint.sh
+++ b/.build_scripts/lint.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,14 @@ cache:
 
 before_install:
 - chmod +x ./.build_scripts/deploy.sh
+- chmod +x ./.build_scripts/lint.sh
+
+before_script:
+- ./.build_scripts/lint.sh || true
+- npm test
 
 script:
 - npm run build
 
 after_success:
-- "./.build_scripts/deploy.sh"
+- ./.build_scripts/deploy.sh

--- a/README.md
+++ b/README.md
@@ -22,3 +22,10 @@ There are two commands, both run via npm.
 The .travis.yml file enables the usage of [Travis](http://travis.org) as a test and deployment system. In this particular case, Travis will be looking for any changes to the repo and when a change is made to the `master` branch, Travis will build the project and deploy it to the `gh-pages` branch.
 
 ## semistandard for linting
+We're using [semistandard](https://github.com/Flet/semistandard) for linting. 
+
+- `npm run lint` - will run linter and warn of any errors.
+
+Travis will run the linter but will not fail a build if errros exist, it will just be present in the logs (we all look at Travis logs, right?).
+
+There are linting plugins for popular editors listed in the semistandard repo.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
   "homepage": "https://github.com/developmentseed/project-seed",
   "scripts": {
     "serve": "gulp serve",
-    "build": "gulp"
+    "build": "gulp",
+    "lint": "semistandard app/scripts/**/*.js",
+    "test": "echo no other tests yet!"
   },
   "devDependencies": {
     "autoprefixer-core": "^4.0.2",
@@ -43,6 +45,7 @@
     "jshint-stylish": "^1.0.0",
     "lodash.assign": "^3.1.0",
     "opn": "^1.0.0",
+    "semistandard": "^4.1.4",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
     "watchify": "^3.2.1"


### PR DESCRIPTION
This adds semistandard as linter of choice. 

`npm run lint` will run linter

Travis runs the linter but will not fail the build if there are errors. Be excellent to each other everyone.