### PR TITLE
Copy over css files in styles dir so they can be included by sass

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -216,6 +216,10 @@ gulp.task('fonts', function () {
 });
 
 gulp.task('extras', function () {
+  gulp.src([
+    'app/assets/styles/*.css'], {
+    dot: true
+  }).pipe(gulp.dest('dist/styles'));
   return gulp.src([
     'app/**/*',
     '!app/*.html',


### PR DESCRIPTION
We ran into an issue on ad-profile where we needed to included css files in the main.scss, so this command will copy over any .css files in the styles directory instead of putting them in vendor.css or main.css. 