### PR TITLE
Update eslint and styles

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+[*.{js}]
+charset = utf-8
+
+# Indentation override for all JS under lib directory
+[lib/**.js]
+indent_style = space
+indent_size = 2
+
+# Matches the exact files either package.json or .travis.yml
+[{package.json,.travis.yml}]
+indent_style = space
+indent_size = 2

--- a/.eslintrc
+++ b/.eslintrc
@@ -4,20 +4,20 @@
     "es6": true,
     "browser": true
   },
-  "plugins": [
-    "react"
-  ],
+  "plugins": ["react"],
   "parserOptions": {
-    "ecmaVersion": 2017,
+    "ecmaVersion": 2018,
     "ecmaFeatures": {
       "jsx": true
     }
   },
   "rules": {
     "semi": [2, "always"],
+    "jsx-quotes": [2, "prefer-single"],
+    "no-console": 2,
     "no-extra-semi": 2,
     "semi-spacing": [2, { "before": false, "after": true }],
-    "react/display-name": 1 ,
+    "react/display-name": 1,
     "react/jsx-no-duplicate-props": 2,
     "react/jsx-no-undef": 2,
     "react/jsx-uses-react": 2,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "prettier.eslintIntegration": true
+}

--- a/README.md
+++ b/README.md
@@ -78,9 +78,14 @@ The script build, which uses `browserify`, outputs two js files: `bundle.js` and
 ## Circle CI for testing and deployment
 The `.circleci/config.yml` file enables the usage of [Circle CI](http://circleci.com/) as a test and deployment system. In this particular case, Travis will be looking for any changes to the repo and when a change is made to the `master` branch, Travis will build the project and deploy it to the `gh-pages` branch.
 
-## semistandard for linting
-We're using [semistandard](https://github.com/Flet/semistandard) for linting.
+## Linting
 
-- `yarn lint` - will run linter and warn of any errors.
+Our [ESLint rules](.eslintrc) are based on `standard` rules, with semicolons enabled. To check  linting errors run:
 
-There are linting plugins for popular editors listed in the semistandard repo.
+    yarn lint
+
+## Coding style
+
+File [.editorconfig](.editorconfig) defines basic code styling rules, like indent sizes. 
+
+[Prettier](https://prettier.io) is the recommended code formatter. Atom and VSCode have extensions supporting Prettier-ESLint integration, which will help maintain style consistency while following linting rules.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -106,7 +106,7 @@ gulp.task('javascript', function () {
           title: 'Oops! Browserify errored:',
           message: e.message
         });
-        console.log('Javascript error:', e);
+        console.log('Javascript error:', e); // eslint-disable-line
         if (prodBuild) {
           process.exit(1);
         }
@@ -167,7 +167,7 @@ gulp.task('styles', function () {
         title: 'Oops! Sass errored:',
         message: e.message
       });
-      console.log('Sass error:', e.toString());
+      console.log('Sass error:', e.toString()); // eslint-disable-line
       if (prodBuild) {
         process.exit(1);
       }


### PR DESCRIPTION
Changes:

- In ESLint:
  - Added `no-console` rule;
  - Set ecmaVersion to `2018`;
  - Added `single-quote` preference for JSX;
- Added .editorconfig file;
- Added recommendation to use Prettier as code formatter.