### PR TITLE
Remove NODE_ENV from env vars

### DIFF
--- a/.github/_workflow-samples/deploy-s3.yml
+++ b/.github/_workflow-samples/deploy-s3.yml
@@ -10,7 +10,6 @@ on:
 
 env:
   NODE: 14
-  NODE_ENV: production
   DEPLOY_BUCKET:
 
 jobs:


### PR DESCRIPTION
If `NODE_ENV=production` is set, `yarn install` will not install the `devDependencies` and the build will fail.
The env will be set when `yarn <command>` runs