### PR TITLE
Fix surge deploy example

### DIFF
--- a/.github/_workflow-samples/deploy-surge.yml
+++ b/.github/_workflow-samples/deploy-surge.yml
@@ -58,9 +58,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Restore dist cache
+      - name: Restore node_modules
         uses: actions/cache@v2
         id: cache-node-modules
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package.json') }}
+    
+      - name: Restore dist cache
+        uses: actions/cache@v2
+        id: cache-dist
         with:
           path: dist
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.sha }}
@@ -68,5 +75,4 @@ jobs:
       - name: Deploy to Surge
         run: |
           cp ./dist/index.html ./dist/200.html
-          npm install -g surge
-          surge ./dist ${{ env.SURGE_DOMAIN }} --token ${{ secrets.SURGE_TOKEN }}
+          node_modules/surge/lib/cli.js ./dist ${{ env.SURGE_DOMAIN }} --token ${{ secrets.SURGE_TOKEN }}


### PR DESCRIPTION
The surge deploy example using Github Actions raises a permission error on `npm install -g surge`, it seems not possible to install modules globally this way. This PR fix this issue by using a local version of surge module. It was tested in [bri-web](https://github.com/developmentseed/bri-web/blob/main/.github/workflows/deploy-staging.yml#L57-L78).