### PR TITLE
fix: Use different template path for dev vs. prod mode

### DIFF
--- a/src/generator/apply-component-library.ts
+++ b/src/generator/apply-component-library.ts
@@ -1,6 +1,7 @@
 import fs from 'fs-extra';
 import path from 'path';
 import { mergePackageDependencies } from './merge-package-dependencies';
+import { getTemplatePath } from './template-paths';
 
 /**
  * Applies the selected component library template to the generated project.
@@ -15,9 +16,8 @@ export async function applyComponentLibrary(
   targetDir: string,
   componentLibrary: string
 ): Promise<void> {
-  const componentLibDir = path.resolve(
-    __dirname,
-    '../../templates/component-library',
+  const componentLibDir = getTemplatePath(
+    'component-library',
     componentLibrary
   );
   if (!(await fs.pathExists(componentLibDir))) {

--- a/src/generator/apply-map-library.ts
+++ b/src/generator/apply-map-library.ts
@@ -1,6 +1,7 @@
 import fs from 'fs-extra';
 import path from 'path';
 import { mergePackageDependencies } from './merge-package-dependencies';
+import { getTemplatePath } from './template-paths';
 
 /**
  * Applies the selected map library template to the generated project.
@@ -19,7 +20,7 @@ export async function applyMapLibrary(
     return;
   }
 
-  const mapLibDir = path.resolve(__dirname, '../../templates/map', mapLibrary);
+  const mapLibDir = getTemplatePath('map', mapLibrary);
 
   if (!(await fs.pathExists(mapLibDir))) {
     throw new Error(`Map library template not found: ${mapLibrary}`);

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -4,6 +4,7 @@ import { createEnvFile } from './create-env-file';
 import { processReadme } from './process-readme';
 import { applyComponentLibrary } from './apply-component-library';
 import { applyMapLibrary } from './apply-map-library';
+import { getTemplatePath } from './template-paths';
 
 /**
  * Main project generation function that orchestrates the entire project creation process.
@@ -24,7 +25,7 @@ export async function generateProject(
   force: boolean,
   targetDir: string
 ): Promise<void> {
-  const baseTemplateDir = path.resolve(__dirname, '../../templates/base');
+  const baseTemplateDir = getTemplatePath('base');
 
   if (await fs.pathExists(targetDir)) {
     if (!force) {

--- a/src/generator/template-paths.ts
+++ b/src/generator/template-paths.ts
@@ -1,0 +1,29 @@
+import path from 'path';
+
+/**
+ * Gets the absolute path to the templates directory.
+ * Handles both development mode (running from TypeScript source) and
+ * production mode (running from compiled JavaScript).
+ *
+ * @returns The absolute path to the templates directory
+ */
+function getTemplatesDir(): string {
+  // Check if we're running from source (development) or compiled (production)
+  const isDev = __dirname.includes('/src/');
+  const relativePath = isDev ? '../../templates' : '../templates';
+  return path.resolve(__dirname, relativePath);
+}
+
+/**
+ * Gets the absolute path to a specific template subdirectory.
+ *
+ * @param subdir - The subdirectory within templates (e.g., 'base', 'component-library', 'map')
+ * @param name - Optional specific template name within the subdirectory
+ * @returns The absolute path to the template directory
+ */
+export function getTemplatePath(subdir: string, name?: string): string {
+  const templatesDir = getTemplatesDir();
+  return name
+    ? path.join(templatesDir, subdir, name)
+    : path.join(templatesDir, subdir);
+}


### PR DESCRIPTION
- Add getTemplatePath utility function to handle path differences between development (src/generator) and production (dist/) environments
- Replace hardcoded path.resolve calls with centralized function across all generator modules (index.ts, apply-component-library.ts, apply-map-library.ts)
- Fix template path resolution issues that caused ENOENT errors when running CLI in different modes
- Ensure consistent behavior between `pnpm start` (dev) and `node dist/index.js` (prod)