### PR TITLE
Custom eslint rules to help with code cleanness

### DIFF
--- a/templates/base/app/app.tsx
+++ b/templates/base/app/app.tsx
@@ -1,5 +1,3 @@
-function App() {
+export default function App() {
   return <div>Hello World</div>;
 }
-
-export default App;

--- a/templates/base/eslint.config.mjs
+++ b/templates/base/eslint.config.mjs
@@ -36,7 +36,25 @@ export default [
       'react/jsx-pascal-case': 'error',
       // Force self closing components when there are no children.
       // Prevents `<MyComp prop='1'></MyComp>`
-      'react/self-closing-comp': 'error'
+      'react/self-closing-comp': 'error',
+      // Disable unused vars, handles TS-specific cases (type params,
+      // interfaces) better than base rule.
+      // https://typescript-eslint.io/rules/no-unused-vars/#what-benefits-does-this-rule-have-over-typescript
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          args: 'all',
+          argsIgnorePattern: '^_',
+          caughtErrors: 'all',
+          caughtErrorsIgnorePattern: '^_',
+          destructuredArrayIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          ignoreRestSiblings: true
+        }
+      ],
+      // Warn when `any` type is used. It's sometimes necessary, but should be
+      // avoided when possible.
+      '@typescript-eslint/no-explicit-any': 'warn'
     }
   }
 ];

--- a/templates/base/eslint.config.mjs
+++ b/templates/base/eslint.config.mjs
@@ -21,12 +21,22 @@ export default [
   {
     name: 'Custom Rules',
     rules: {
-      'no-console': 2,
+      // Helps with cleaning debug statements by erroring on console.
+      'no-console': 'error',
+      // It's no longer needed to import React, so this just prevents weird
+      // errors when you don't.
       'react/react-in-jsx-scope': 'off',
-      'react/no-array-index-key': 2,
-      'react-hooks/rules-of-hooks': 2, // Checks rules of Hooks
-      'react/jsx-pascal-case': 2,
-      'react/self-closing-comp': 2
+      // Array indexes as keys should not be used. The occasional time it is
+      // needed, an ignore can be added.
+      'react/no-array-index-key': 'error',
+      // Helps with enforcing rules of hooks. Very helpful to catch wrongly
+      // placed hooks, like conditional usage.
+      'react-hooks/rules-of-hooks': 'error',
+      // Ensure that components are PascalCase
+      'react/jsx-pascal-case': 'error',
+      // Force self closing components when there are no children.
+      // Prevents `<MyComp prop='1'></MyComp>`
+      'react/self-closing-comp': 'error'
     }
   }
 ];

--- a/templates/base/eslint.config.mjs
+++ b/templates/base/eslint.config.mjs
@@ -17,5 +17,16 @@ export default [
   pluginJs.configs.recommended,
   ...tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
-  eslintPluginPrettierRecommended,  
+  eslintPluginPrettierRecommended,
+  {
+    name: 'Custom Rules',
+    rules: {
+      'no-console': 2,
+      'react/react-in-jsx-scope': 'off',
+      'react/no-array-index-key': 2,
+      'react-hooks/rules-of-hooks': 2, // Checks rules of Hooks
+      'react/jsx-pascal-case': 2,
+      'react/self-closing-comp': 2
+    }
+  }
 ];

--- a/templates/component-library/chakra/main.tsx
+++ b/templates/component-library/chakra/main.tsx
@@ -1,3 +1,4 @@
+import { ChakraProvider } from '@chakra-ui/react';
 import { useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
 import { ChakraProvider } from '@chakra-ui/react';

--- a/templates/component-library/uswds/app.tsx
+++ b/templates/component-library/uswds/app.tsx
@@ -1,6 +1,6 @@
 import { Header, Grid, GridContainer, Title } from '@trussworks/react-uswds';
 
-function App() {
+export default function App() {
   return (
     <>
       <Header>
@@ -31,5 +31,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/templates/component-library/uswds/main.tsx
+++ b/templates/component-library/uswds/main.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
 import '@trussworks/react-uswds/lib/uswds.css';


### PR DESCRIPTION
Split from #126.
Including the additional lint rules for further discussion.

I think these additional rules, not only improve code cleanness, but also help avoid some bugs and discouraged behaviors.

```
{
    name: 'Custom Rules',
    rules: {
      // Helps with cleaning debug statements by erroring on console.
      'no-console': 'error',
      // It's no longer needed to import React, so this just prevents weird
      // errors when you don't.
      'react/react-in-jsx-scope': 'off',
      // Array indexes as keys should not be used. The occasional time it is
      // needed, an ignore can be added.
      'react/no-array-index-key': 'error',
      // Helps with enforcing rules of hooks. Very helpful to catch wrongly
      // placed hooks, like conditional usage.
      'react-hooks/rules-of-hooks': 'error',
      // Ensure that components are PascalCase
      'react/jsx-pascal-case': 'error',
      // Force self closing components when there are no children.
      // Prevents `<MyComp prop='1'></MyComp>`
      'react/self-closing-comp': 'error',
      // Disable unused vars, handles TS-specific cases (type params,
      // interfaces) better than base rule.
      // https://typescript-eslint.io/rules/no-unused-vars/#what-benefits-does-this-rule-have-over-typescript
      '@typescript-eslint/no-unused-vars': [
        'error',
        {
          args: 'all',
          argsIgnorePattern: '^_',
          caughtErrors: 'all',
          caughtErrorsIgnorePattern: '^_',
          destructuredArrayIgnorePattern: '^_',
          varsIgnorePattern: '^_',
          ignoreRestSiblings: true
        }
      ],
      // Warn when `any` type is used. It's sometimes necessary, but should be
      // avoided when possible.
      '@typescript-eslint/no-explicit-any': 'warn'
    }
  }
```