### PR TITLE
docs: Add generate script and update README usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,19 +49,19 @@ For production use or when you want to run the compiled version:
 pnpm build
 
 # Run the built version
-node ./dist/index.js
+pnpm generate
 
 # Generate with specific project name and component library
-node ./dist/index.js my-project-name --component-library chakra
+pnpm generate my-project-name --component-library chakra
 
 # Generate with specific project name, component library, and map library
-node ./dist/index.js my-project-name --component-library chakra --map-library mapbox-gl
+pnpm generate my-project-name --component-library chakra --map-library mapbox-gl
 
 # Show help
-node ./dist/index.js --help
+pnpm generate --help
 
 # Show version
-node ./dist/index.js --version
+pnpm generate --version
 ```
 
 ### Component Library Options

--- a/package.json
+++ b/package.json
@@ -10,9 +10,10 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup",
     "dev": "tsup --watch",
     "start": "tsx src/index.ts",
+    "build": "tsup",
+    "generate": "node ./dist/index.js",
     "generate-all": "./scripts/generate-all.sh",
     "lint": "eslint src/",
     "type-check": "tsc --noEmit"


### PR DESCRIPTION
This PR introduces a new generate script to package.json, allowing users to run the CLI with pnpm generate instead of directly invoking node ./dist/index.js. The README has been updated to reflect this change, making usage instructions more consistent and user-friendly. This improves the developer experience by aligning CLI execution with other project scripts and simplifying command usage.

This is mainly for my own convenience :) 