### PR TITLE
chore: add Dependabot config for CLI and template dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,134 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "dependabot"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    groups:
+      cli-prod-deps:
+        dependency-type: "production"
+        patterns:
+          - "*"
+      cli-dev-deps:
+        dependency-type: "development"
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/templates/base"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "dependabot"
+      - "templates"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    groups:
+      template-base-prod-deps:
+        dependency-type: "production"
+        patterns:
+          - "*"
+      template-base-dev-deps:
+        dependency-type: "development"
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/templates/component-library/chakra"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "dependabot"
+      - "templates"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    groups:
+      template-chakra-deps:
+        dependency-type: "production"
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/templates/component-library/uswds"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "dependabot"
+      - "templates"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    groups:
+      template-uswds-deps:
+        dependency-type: "production"
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/templates/map/mapbox-gl"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "dependabot"
+      - "templates"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    groups:
+      template-mapbox-deps:
+        dependency-type: "production"
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/templates/map/maplibre-gl"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "dependabot"
+      - "templates"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    groups:
+      template-maplibre-deps:
+        dependency-type: "production"
+        patterns:
+          - "*"

--- a/README.md
+++ b/README.md
@@ -126,6 +126,22 @@ pnpm lint
 pnpm type-check
 ```
 
+### Dependency Updates (Dependabot)
+
+This repository uses Dependabot to keep both the CLI and starter templates up-to-date:
+
+- `package.json` at the repository root is checked weekly.
+- Template manifests under `templates/` are checked monthly.
+- Updates are grouped to reduce PR noise.
+
+When Dependabot opens PRs:
+
+1. Run checks for the CLI (`pnpm lint`, `pnpm type-check`, `pnpm build`)
+2. Generate all combinations (`pnpm generate-all`) and spot-check installs for generated apps
+3. Merge patch/minor updates quickly; review majors with extra care
+
+Dependabot config lives at `.github/dependabot.yml`.
+
 ## Generated Projects
 
 Projects are generated in `generated/` directory. This directory is gitignored to prevent generated projects from being committed.
@@ -143,7 +159,7 @@ Projects are generated in `generated/` directory. This directory is gitignored t
 
 The CLI uses a modular template system:
 
-```
+```text
 templates/
 ├── base/                    # Base template (core project files)
 │   ├── app/


### PR DESCRIPTION
## Summary

- Add Dependabot configuration at `.github/dependabot.yml` to monitor npm dependencies in root and template package manifests.
- Use grouped updates to reduce PR noise and keep maintenance manageable.
- Add maintainer guidance in `README.md` for handling dependency update PRs.
- Fix markdown fenced code language in `README.md`.

## Why

- Keep starter outputs fresher by continuously updating dependency versions in template sources.
- Separate update cadence: weekly for CLI root dependencies, monthly for template dependencies.

## Validation

- Confirmed no diagnostics in Dependabot config and README edits.

--------
✨ AI-assisted changes!