### PR TITLE
chore: add Renovate configuration for dependency management

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,21 @@ pnpm lint
 pnpm type-check
 ```
 
+### Dependency Updates (Renovate)
+
+This repository uses Renovate to keep both the CLI and starter templates up-to-date:
+
+- `renovate.json` at the repository root controls update behavior.
+- Root dependencies are checked weekly.
+- Template dependencies under `templates/` are grouped monthly for non-major updates.
+- Template major updates require approval through the Renovate Dependency Dashboard.
+
+When Renovate opens PRs:
+
+1. Run checks for the CLI (`pnpm lint`, `pnpm type-check`, `pnpm build`)
+2. Generate all combinations (`pnpm generate-all`) and spot-check installs for generated apps
+3. Merge patch/minor updates quickly; review majors with extra care
+
 ## Generated Projects
 
 Projects are generated in `generated/` directory. This directory is gitignored to prevent generated projects from being committed.
@@ -143,7 +158,7 @@ Projects are generated in `generated/` directory. This directory is gitignored t
 
 The CLI uses a modular template system:
 
-```
+```text
 templates/
 ├── base/                    # Base template (core project files)
 │   ├── app/

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "timezone": "UTC",
+  "labels": [
+    "dependencies",
+    "renovate"
+  ],
+  "dependencyDashboard": true,
+  "rebaseWhen": "behind-base-branch",
+  "rangeStrategy": "bump",
+  "prConcurrentLimit": 10,
+  "prHourlyLimit": 2,
+  "schedule": [
+    "before 10:00 on monday"
+  ],
+  "ignorePaths": [
+    "generated/**",
+    "**/node_modules/**",
+    "dist/**"
+  ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": [
+      "before 10:00 on monday"
+    ]
+  },
+  "packageRules": [
+    {
+      "description": "Group non-major updates for template package manifests",
+      "matchManagers": [
+        "npm"
+      ],
+      "matchFileNames": [
+        "templates/**/package.json"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ],
+      "groupName": "template non-major dependencies",
+      "labels": [
+        "dependencies",
+        "renovate",
+        "templates"
+      ],
+      "schedule": [
+        "on the first monday of the month"
+      ]
+    },
+    {
+      "description": "Keep template major updates isolated and manually reviewed",
+      "matchManagers": [
+        "npm"
+      ],
+      "matchFileNames": [
+        "templates/**/package.json"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "template major dependencies",
+      "dependencyDashboardApproval": true,
+      "labels": [
+        "dependencies",
+        "renovate",
+        "templates",
+        "major"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
# Dependabot (#133) vs Renovate for `project-seed`

This branch uses [Renovate](https://docs.renovatebot.com/) via `renovate.json`.

## Quick summary

- Dependabot is simpler to set up and is built into GitHub.
- Renovate is more flexible for grouping, schedules, and update policy.
- For `project-seed` (multiple template `package.json` files), Renovate usually gives cleaner, lower-noise maintenance.

## Feature comparison

| Area                          | Dependabot                                            | Renovate                                                                        |
| ----------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------- |
| Setup                         | Native GitHub config in `.github/dependabot.yml`      | App/service + `renovate.json`                                                   |
| Ecosystem support for JS/pnpm | Uses `package-ecosystem: npm` for npm/yarn/pnpm repos | Native npm manager with pnpm lockfile support                                   |
| Grouping updates              | Available, but more limited and verbose               | Very flexible (`packageRules`, grouping by path/type/update type)               |
| Scheduling                    | Per-update block schedule                             | Global + per-rule schedules                                                     |
| PR noise control              | Basic limits and groups                               | Fine-grained limits, grouping, dashboard approvals                              |
| Advanced policy               | Limited                                               | Rich policy controls (approval gates, semantic commit presets, automerge rules) |
| Best fit                      | Smaller/simple repos                                  | Monorepos and template-heavy repos                                              |

## What this Renovate config does

- Scans npm ecosystem dependencies (including pnpm lockfile at root).
- Runs weekly updates by default (Monday morning UTC).
- Ignores generated output in `generated/**`.
- Enables lock file maintenance weekly.
- Groups template non-major updates monthly (first Monday).
- Requires dashboard approval for template major updates.

## Strategy for starter template freshness

To keep generated projects current while avoiding breakage:

1. Merge patch/minor template updates regularly.
2. Review major template updates separately and test generated variants before merge.
3. Keep root CLI updates frequent (weekly) and template updates batched (monthly).
4. Keep CI checks on dependency PRs (`lint`, `type-check`, `build`, `generate-all`).

## Recommendation

If you want maximum control and less PR noise over time, use Renovate.
If you want the easiest built-in option with minimal moving parts, use Dependabot.

For `project-seed`, Renovate is the stronger long-term option because template dependency updates can be grouped and scheduled with more precision.

## Renovate setup checklist (after push)

- [ ] Install/authorize the Renovate GitHub App for `developmentseed/project-seed`.
- [ ] Confirm Renovate can open PRs against the default branch.
- [ ] Merge the first Renovate onboarding/config PR (if shown).
- [ ] Ensure CI runs for Renovate PRs and required checks are configured.
- [ ] Decide merge policy: manual review only, or auto-merge for patch/minor updates.
- [ ] Verify branch protection rules allow your chosen bot merge flow.
- [ ] Monitor the Dependency Dashboard issue and approve major template updates there.
- [ ] (Optional) Add CODEOWNERS/labels for dependency PR triage.

--------
✨ AI-assisted changes!