### PR TITLE
feat: auto-create initial commit after project generation

### DIFF
--- a/src/generator/setup-git-hooks.ts
+++ b/src/generator/setup-git-hooks.ts
@@ -10,11 +10,14 @@ import path from 'path';
  */
 export async function setupGitHooks(targetDir: string): Promise<void> {
   try {
+    let initializedGitRepo = false;
+
     // Initialize git repository if it doesn't exist
     const gitDir = path.join(targetDir, '.git');
     if (!(await fs.pathExists(gitDir))) {
       try {
         execSync('git init', { cwd: targetDir, stdio: 'inherit' });
+        initializedGitRepo = true;
       } catch (gitInitError) {
         if (gitInitError instanceof Error) {
           // eslint-disable-next-line no-console
@@ -52,6 +55,30 @@ export async function setupGitHooks(targetDir: string): Promise<void> {
         if (stats.isFile()) {
           // Make the hook file executable (0o755 = rwxr-xr-x)
           await fs.chmod(hookPath, 0o755);
+        }
+      }
+    }
+
+    if (initializedGitRepo) {
+      execSync('git add .', {
+        cwd: targetDir,
+        stdio: 'inherit'
+      });
+
+      try {
+        execSync('git commit -m "Initial commit from project-seed"', {
+          cwd: targetDir,
+          stdio: 'inherit'
+        });
+      } catch (gitCommitError) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          'Warning: Failed to create initial commit automatically. You can run `git add . && git commit -m "Initial commit from project-seed"` manually.'
+        );
+
+        if (gitCommitError instanceof Error) {
+          // eslint-disable-next-line no-console
+          console.warn(`Details: ${gitCommitError.message}`);
         }
       }
     }

--- a/src/generator/setup-git-hooks.ts
+++ b/src/generator/setup-git-hooks.ts
@@ -66,10 +66,13 @@ export async function setupGitHooks(targetDir: string): Promise<void> {
       });
 
       try {
-        execSync('git commit -m "Initial commit from project-seed"', {
-          cwd: targetDir,
-          stdio: 'inherit'
-        });
+        execSync(
+          'git commit --no-verify -m "Initial commit from project-seed"',
+          {
+            cwd: targetDir,
+            stdio: 'inherit'
+          }
+        );
       } catch (gitCommitError) {
         // eslint-disable-next-line no-console
         console.warn(


### PR DESCRIPTION
Close #131 

- Automatically creates an initial Git commit after generating a new project.
- Keeps existing Git setup behavior (repo init + Husky hooks path + executable hook files).
- Uses a neutral default commit message: Initial commit from project-seed.

## Implementation

Updated setup-git-hooks.ts to:

- Detect when a new repo is initialized.
- Run git add . and git commit -m "Initial commit from project-seed" for newly initialized repos.
- Continue generation if commit fails (e.g., missing Git identity), with a clear warning and manual fallback command.

## Why

- Ensures scaffolded output is captured as a clean baseline commit.
- Reduces manual setup steps and prevents forgetting the first commit.

## Notes

Commit creation is best-effort and non-blocking by design.

Follow-up fix: skip hooks for initial auto-commit
